### PR TITLE
front page theft link is broken

### DIFF
--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -12,7 +12,7 @@
           By sharing our experiences with each other and with researchers and relevant agencies, we can make bicycling safer and more fun.
         %p.padded
           %strong
-            Check out our #{link_to "map of theft data", "http://maps.bikewise.org"}.
+            Check out our #{link_to "map of theft data", "http://map.bikewise.org"}.
           %small
             (#{link_to "source code", "https://github.com/sethherr/bikewise_maps"})
 


### PR DESCRIPTION
Fixes 404 error when clicking on the "map of theft data" link and removes an extraneous whitespace (vim did it automatically). I can add it back if it's necessary that we keep it for page formatting reasons.
